### PR TITLE
No-op exit for lock contention.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -198,7 +198,7 @@ calling shell**. This is the case whether it's run from cron or not.
 History
 =======
 
- * 2010/10/04 - added idempotency to allow run lock contention to be treated as a no-op
+ * 2010/10/04 - added idempotency to allow run lock contention to be treated as a no-op (Mike Cerna, Groupon)
  * 2009/06/25 — added lockf() support for Solaris 10 (thanks to Michal Bella)
  * 2009/03/09 — Tracked on GitHub by Peter Harkins.
  * 2006/06/03 — initial release by Stephen J. Friedl. <http://unixwiz.net/archives/2006/06/new_tool_lockru.html>

--- a/README.markdown
+++ b/README.markdown
@@ -163,6 +163,9 @@ We'll note that command-line redirection (`> /dev/null`, etc.) is not
 supported by this or the command which follows -- it's handled **by the
 calling shell**. This is the case whether it's run from cron or not.
 
+ * `--idempotent`
+
+  > Allows silent successful exit when lock contention is encountered.
 
  * `--lockfile=[filename]`
 
@@ -195,6 +198,7 @@ calling shell**. This is the case whether it's run from cron or not.
 History
 =======
 
+ * 2010/10/04 - added idempotency to allow run lock contention to be treated as a no-op
  * 2009/06/25 — added lockf() support for Solaris 10 (thanks to Michal Bella)
  * 2009/03/09 — Tracked on GitHub by Peter Harkins.
  * 2006/06/03 — initial release by Stephen J. Friedl. <http://unixwiz.net/archives/2006/06/new_tool_lockru.html>

--- a/lockrun.c
+++ b/lockrun.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
 		if ( ! wait_for_lock )
 		{
 			
-			if(idempotent) /* GROUPON: given the idempotent flag, we treat contention as a no-op */
+			if(idempotent) /* given the idempotent flag, we treat contention as a no-op */
 			{
 				exit(EXIT_SUCCESS);
 			}

--- a/lockrun.c
+++ b/lockrun.c
@@ -32,6 +32,7 @@ static mode_t		openmode = 0666;
 static int		sleeptime = 10;		/* seconds */
 static int		Verbose = FALSE;
 static int		Maxtime  = 0;
+static int		idempotent = FALSE;
 
 static char *getarg(char *opt, char ***pargv);
 
@@ -96,6 +97,11 @@ int main(int argc, char **argv)
 		{
 			Verbose++;
 		}
+		
+		else if ( STRMATCH(arg, "-I") || STRMATCH(arg, "--idempotent"))
+		{
+			idempotent = TRUE;
+		}
 
 		else
 		{
@@ -130,7 +136,15 @@ int main(int argc, char **argv)
 	{
 		if ( ! wait_for_lock )
 		{
-			die("ERROR: cannot launch %s - run is locked", argv[0]);
+			
+			if(idempotent) /* GROUPON: given the idempotent flag, we treat contention as a no-op */
+			{
+				exit(EXIT_SUCCESS);
+			}
+			else
+			{
+				die("ERROR: cannot launch %s - run is locked", argv[0]);
+			}
 		}
 
 		/* waiting */


### PR DESCRIPTION
Hey Peter, we use this at my company for certain actions to fail gracefully. Basically...

We have a cheap queue of activity that needs to get executed. Our cronjob checks every minute for work to do, and when it encounters new work, it'll typically take an hour to run! We use lockrun to ensure that we can run that 'check' every minute so that work immediately starts happening when available, but subsequent lockruns should just exit silently instead of throwing a fatal exception! This is configurable because not all uses of lockrun are run against idempotent actions.

Thanks!
