### PR TITLE
fix lockrun to return child process's exit status

### DIFF
--- a/lockrun.c
+++ b/lockrun.c
@@ -168,18 +168,21 @@ int main(int argc, char **argv)
 	{
 		time_t endtime;
 		pid_t  pid;
+		int    status;
 
 		if ( Verbose )
 		    printf("Waiting for process %ld\n", (long) childpid);
 
-		pid = waitpid(childpid, &rc, 0);
+		pid = waitpid(childpid, &status, 0);
+		rc = WEXITSTATUS(status);
 
 		time(&endtime);
 
 		endtime -= starttime;
 
 		if ( Verbose || (Maxtime > 0  &&  endtime > Maxtime) )
-		    printf("pid %d exited with status %d (time=%ld sec)\n", pid, rc, endtime);
+		    printf("pid %d exited with status %d, exit code: %d (time=%ld sec)\n",
+			   pid, status, rc, endtime);
 	}
 	else
 	{


### PR DESCRIPTION
The previous code was incorrectly exiting with the value returned in
waipid()'s status parameter, which is not simply the exit status of the
child process, but instead an aggregated status variable representing a
few different reasons for waitpid()'s return.   This prevented
invocations of lockrun from correctly returning exit status values that
were non-zero.  To fix this we just need to parse the exit code out of
the status variable using the WEXITSTATUS macro.

Expected error code:

  % ls /doesnotexist
  ls: /doesnotexist: No such file or directory
  % echo $?
  2

Wrong error code from previous lockrun implementation:

  % lockrun -V --lockfile=/tmp/lock.1 -- ls /doesnotexist
  ls: /doesnotexist: No such file or directory
  Waiting for process 14266
  pid 14266 exited with status 512 (time=0 sec)
  % echo $?
  0

Note that the value 512 was being truncated because exit codes are
expected to be 1 byte (with values between 0 and 255).

After this fix, the exit status is properly passed back:

  % lockrun -V --lockfile=/tmp/lock.1 -- ls /doesnotexist
  ls: /doesnotexist: No such file or directory
  Waiting for process 15114
  pid 15114 exited with status 512, exit code: 2 (time=0 sec)
  ls: /doesnotexist: No such file or directory
  % echo $?
  2

P.S., interestingly, the previous contributor to this project was also
from Groupon, Mike Cerna.
P.P.S., tabs are evil.
