### PR TITLE
Set RC when execvp fails

### DIFF
--- a/lockrun.c
+++ b/lockrun.c
@@ -162,7 +162,8 @@ int main(int argc, char **argv)
 	{
 		close(lfd);		// don't need the lock file
 
-		execvp(argv[0], argv);
+		/* Set rc to the result of execvp. This lets the parent know we failed. */
+		rc = execvp(argv[0], argv);
 	}
 	else if ( childpid > 0 )
 	{


### PR DESCRIPTION
When `execvp` in the child process fails, we do not set `rc` to anything useful. We do `exit` using `rc`. The exit code is then random.

Here, `b.sh` is `chmod 644` and cannot be executed, thus `execvp` fails:

```
allard@allard:~/devel/byte$ lockrun --verbose --quiet -L .lock -- ./b.sh; echo $?
Waiting for process 21448
pid 21448 exited with status 12288, exit code: 48 (time=0 sec)
48
allard@allard:~/devel/byte$ lockrun --verbose --quiet -L .lock -- ./b.sh; echo $?
Waiting for process 21472
pid 21472 exited with status 4096, exit code: 16 (time=0 sec)
16
allard@allard:~/devel/byte$ lockrun --verbose --quiet -L .lock -- ./b.sh; echo $?
Waiting for process 21493
pid 21493 exited with status 45056, exit code: 176 (time=0 sec)
176
allard@allard:~/devel/byte$ lockrun --verbose --quiet -L .lock -- ./b.sh; echo $?
Waiting for process 21502
pid 21502 exited with status 8192, exit code: 32 (time=0 sec)
32
```

This patch sets rc to the return code of execvp (often 255).

```
(master *% u=) allard@allard:~/devel/byte/lockrun$ ./lockrun --verbose --quiet -L .lock -- ../b.sh; echo $?
Waiting for process 10264
pid 10264 exited with status 65280, exit code: 255 (time=0 sec)
255
(master *% u=) allard@allard:~/devel/byte/lockrun$ ./lockrun --verbose --quiet -L .lock -- ../b.sh; echo $?
Waiting for process 10308
pid 10308 exited with status 65280, exit code: 255 (time=0 sec)
255
```

Old behaviour intact (a.sh is chmod 755)

```
(master *% u=) allard@allard:~/devel/byte/lockrun$ ./lockrun --verbose --quiet -L .lock -- ../a.sh; echo $?
Waiting for process 10843
pid 10843 exited with status 0, exit code: 0 (time=0 sec)
0
```
